### PR TITLE
feat: Overrides support

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,44 @@
+
+/**
+ * Recursively applies Partial
+ * to all keys in T
+ */
+export type DeepPartial<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>;
+};
+
+
+/**
+ * Returns an object that maps
+ * all the keys of T to unknown
+ */
+export type RequiredKeys<T> = {
+  [K in keyof Required<T>]: unknown;
+};
+
+/**
+ * Returns an object that partially maps
+ * all the keys of T to unknown
+ */
+export type PartialKeys<T> = {
+  [K in keyof T]?: unknown
+};
+
+
+/**
+ * Defines the shape of the options
+ * that can be passed to a mock function
+ */
+export interface MockOptions<T> {
+  override?: DeepPartial<T> | (() => DeepPartial<T>)
+}
+
+/**
+ * Defines a collection of mocks
+ */
+export type Mocks<T> = Record<string, T>;
+
+/**
+ * Defines a mocks
+ */
+export type MocksGenerator = <T>() => Mocks<T>;

--- a/tests/array.spec.ts
+++ b/tests/array.spec.ts
@@ -1,19 +1,10 @@
-import { generateInvalidArrays, generateValidArrays } from '../src/fields';
+import { DeepPartial } from '../src/types';
 import { arrayFields } from './fields';
-import { invalidateGroup, validateGroup } from './mixins';
+import { overrideTest, validationTests } from './mixins';
 
 describe('array', () => {
-  arrayFields.forEach(([description, field]) => {
-    describe(description, () => {
-      describe('validates', () => {
-        const valid = generateValidArrays(field);
-        validateGroup(field, valid);
-      });
-
-      describe('invalidates', () => {
-        const valid = generateInvalidArrays(field);
-        invalidateGroup(field, valid);
-      });
-    });
-  });
+  validationTests(arrayFields);
+  overrideTest(arrayFields, [1, 2, 3] as DeepPartial<unknown>[]);
+  overrideTest(arrayFields, ['a', 'b', 'c'] as DeepPartial<unknown>[]);
+  overrideTest(arrayFields, [] as DeepPartial<unknown>[]);
 });

--- a/tests/literal.spec.ts
+++ b/tests/literal.spec.ts
@@ -1,19 +1,9 @@
-import { mockInvalid, mockValid } from '../src/literal';
 import { literalFields } from './fields';
-import { invalidateGroup, validateGroup } from './mixins';
+import { overrideTest, validationTests } from './mixins';
 
 describe('literal', () => {
-  literalFields.forEach(([description, field]) => {
-    describe(description, () => {
-      describe('validates', () => {
-        const valid = mockValid(field);
-        validateGroup(field, valid);
-      });
-
-      describe('invalidates', () => {
-        const valid = mockInvalid(field);
-        invalidateGroup(field, valid);
-      });
-    });
-  });
+  validationTests(literalFields);
+  overrideTest(literalFields, 'z');
+  overrideTest(literalFields, 999);
+  overrideTest(literalFields, true);
 });

--- a/tests/mixins.ts
+++ b/tests/mixins.ts
@@ -1,5 +1,8 @@
 import * as zod from 'zod';
 
+import { mock } from '../src/fields';
+import { DeepPartial } from '../src/types';
+
 /**
  * Validates each entry of the given group
  *
@@ -26,6 +29,73 @@ export const invalidateGroup = (field: zod.ZodAny, group: Record<string, unknown
     it(`Invalidates ${key}`, () => {
       const failure = () => field.parse(value);
       expect(failure).toThrowErrorMatchingSnapshot();
+    });
+  });
+};
+
+/**
+ * Validates fields
+ *
+ * @param instances
+ */
+export const validationTests = (instances: [string, zod.ZodAny][]) => {
+  instances.forEach(([description, field]) => {
+    describe(description, () => {
+      const { valid, invalid } = mock(field);
+
+      describe('validates', () => {
+        validateGroup(field, valid);
+      });
+
+      describe('invalidates', () => {
+        invalidateGroup(field, invalid);
+      });
+    });
+  });
+};
+
+/**
+ * Tests overrides
+ *
+ * @param instances
+ * @param override
+ */
+export const overrideTest = <T extends zod.ZodAny>(instances: [string, T][], override: DeepPartial<zod.infer<T>>) => {
+  instances.forEach(([description, field]) => {
+    describe(description, () => {
+      describe(`overrides ${description}`, () => {
+        describe('as value', () => {
+          const { valid, invalid } = mock(field, { override });
+
+          Object.entries(valid).forEach(([name, value]) => {
+            it(name, () => {
+              expect(value).toEqual(override);
+            });
+          });
+
+          Object.entries(invalid).forEach(([name, value]) => {
+            it(name, () => {
+              expect(value).toEqual(override);
+            });
+          });
+        });
+
+        describe('as function', () => {
+          const { valid, invalid } = mock(field, { override: () => override });
+
+          Object.entries(valid).forEach(([name, value]) => {
+            it(name, () => {
+              expect(value).toEqual(override);
+            });
+          });
+
+          Object.entries(invalid).forEach(([name, value]) => {
+            it(name, () => {
+              expect(value).toEqual(override);
+            });
+          });
+        });
+      });
     });
   });
 };

--- a/tests/primitives/any.spec.ts
+++ b/tests/primitives/any.spec.ts
@@ -1,19 +1,9 @@
-import * as any from '../../src/primitives/any';
+import { DeepPartial } from '../../src/types';
 import { anyFields } from '../fields';
-import { invalidateGroup, validateGroup } from '../mixins';
+import { overrideTest, validationTests } from '../mixins';
 
 describe('any', () => {
-  anyFields.forEach(([description, field]) => {
-    describe(description, () => {
-      describe('validates', () => {
-        const valid = any.mockValid(field);
-        validateGroup(field, valid);
-      });
-
-      describe('invalidates', () => {
-        const valid = any.mockInvalid(field);
-        invalidateGroup(field, valid);
-      });
-    });
-  });
+  validationTests(anyFields);
+  overrideTest(anyFields, 'Dante Alighieri' as DeepPartial<unknown>);
+  overrideTest(anyFields, 1265 as DeepPartial<unknown>);
 });

--- a/tests/primitives/bigint.spec.ts
+++ b/tests/primitives/bigint.spec.ts
@@ -1,19 +1,8 @@
-import * as bigint from '../../src/primitives/bigint';
 import { bigintFields } from '../fields';
-import { invalidateGroup, validateGroup } from '../mixins';
+import { overrideTest, validationTests } from '../mixins';
 
 describe('bigint', () => {
-  bigintFields.forEach(([description, field]) => {
-    describe(description, () => {
-      describe('validates', () => {
-        const valid = bigint.mockValid(field);
-        validateGroup(field, valid);
-      });
-
-      describe('invalidates', () => {
-        const valid = bigint.mockInvalid(field);
-        invalidateGroup(field, valid);
-      });
-    });
-  });
+  validationTests(bigintFields);
+  overrideTest(bigintFields, BigInt(100));
+  overrideTest(bigintFields, BigInt(-100));
 });

--- a/tests/primitives/boolean.spec.ts
+++ b/tests/primitives/boolean.spec.ts
@@ -1,19 +1,8 @@
-import * as boolean from '../../src/primitives/boolean';
 import { booleanFields } from '../fields';
-import { invalidateGroup, validateGroup } from '../mixins';
+import { overrideTest, validationTests } from '../mixins';
 
 describe('boolean', () => {
-  booleanFields.forEach(([description, field]) => {
-    describe(description, () => {
-      describe('validates', () => {
-        const valid = boolean.mockValid(field);
-        validateGroup(field, valid);
-      });
-
-      describe('invalidates', () => {
-        const valid = boolean.mockInvalid(field);
-        invalidateGroup(field, valid);
-      });
-    });
-  });
+  validationTests(booleanFields);
+  overrideTest(booleanFields, true);
+  overrideTest(booleanFields, false);
 });

--- a/tests/primitives/date.spec.ts
+++ b/tests/primitives/date.spec.ts
@@ -1,19 +1,7 @@
-import * as date from '../../src/primitives/date';
 import { dateFields } from '../fields';
-import { invalidateGroup, validateGroup } from '../mixins';
+import { overrideTest, validationTests } from '../mixins';
 
 describe('date', () => {
-  dateFields.forEach(([description, field]) => {
-    describe(description, () => {
-      describe('validates', () => {
-        const valid = date.mockValid(field);
-        validateGroup(field, valid);
-      });
-
-      describe('invalidates', () => {
-        const valid = date.mockInvalid(field);
-        invalidateGroup(field, valid);
-      });
-    });
-  });
+  validationTests(dateFields);
+  overrideTest(dateFields, new Date('1265-05-01'));
 });

--- a/tests/primitives/null.spec.ts
+++ b/tests/primitives/null.spec.ts
@@ -1,19 +1,7 @@
-import * as znull from '../../src/primitives/null';
 import { nullFields } from '../fields';
-import { invalidateGroup, validateGroup } from '../mixins';
+import { overrideTest, validationTests } from '../mixins';
 
 describe('null', () => {
-  nullFields.forEach(([description, field]) => {
-    describe(description, () => {
-      describe('validates', () => {
-        const valid = znull.mockValid(field);
-        validateGroup(field, valid);
-      });
-
-      describe('invalidates', () => {
-        const valid = znull.mockInvalid(field);
-        invalidateGroup(field, valid);
-      });
-    });
-  });
+  validationTests(nullFields);
+  overrideTest(nullFields, null);
 });

--- a/tests/primitives/number.spec.ts
+++ b/tests/primitives/number.spec.ts
@@ -1,19 +1,12 @@
-import * as number from '../../src/primitives/number';
 import { numberFields } from '../fields';
-import { invalidateGroup, validateGroup } from '../mixins';
+import { overrideTest, validationTests } from '../mixins';
 
 describe('number', () => {
-  numberFields.forEach(([description, field]) => {
-    describe(description, () => {
-      describe('validates', () => {
-        const valid = number.mockValid(field);
-        validateGroup(field, valid);
-      });
-
-      describe('invalidates', () => {
-        const valid = number.mockInvalid(field);
-        invalidateGroup(field, valid);
-      });
-    });
-  });
+  validationTests(numberFields);
+  overrideTest(numberFields, 0);
+  overrideTest(numberFields, 1);
+  overrideTest(numberFields, -1);
+  overrideTest(numberFields, Math.PI);
+  overrideTest(numberFields, Infinity);
+  overrideTest(numberFields, -Infinity);
 });

--- a/tests/primitives/string.spec.ts
+++ b/tests/primitives/string.spec.ts
@@ -1,19 +1,8 @@
-import * as string from '../../src/primitives/string';
 import { stringFields } from '../fields';
-import { invalidateGroup, validateGroup } from '../mixins';
+import { overrideTest, validationTests } from '../mixins';
 
 describe('string', () => {
-  stringFields.forEach(([description, field]) => {
-    describe(description, () => {
-      describe('validates', () => {
-        const valid = string.mockValid(field);
-        validateGroup(field, valid);
-      });
-
-      describe('invalidates', () => {
-        const valid = string.mockInvalid(field);
-        invalidateGroup(field, valid);
-      });
-    });
-  });
+  validationTests(stringFields);
+  overrideTest(stringFields, 'my-string');
+  overrideTest(stringFields, '');
 });

--- a/tests/primitives/undefined.spec.ts
+++ b/tests/primitives/undefined.spec.ts
@@ -1,19 +1,6 @@
-import * as zundefined from '../../src/primitives/undefined';
 import { undefinedFields } from '../fields';
-import { invalidateGroup, validateGroup } from '../mixins';
+import { validationTests } from '../mixins';
 
 describe('undefined', () => {
-  undefinedFields.forEach(([description, field]) => {
-    describe(description, () => {
-      describe('validates', () => {
-        const valid = zundefined.mockValid(field);
-        validateGroup(field, valid);
-      });
-
-      describe('invalidates', () => {
-        const valid = zundefined.mockInvalid(field);
-        invalidateGroup(field, valid);
-      });
-    });
-  });
+  validationTests(undefinedFields);
 });


### PR DESCRIPTION
As a library user, when I generate mocks I'd like to specify mocks for some or all of the fields of my field / model. This is because:

1. I want more control over the generated mock, or
2. I want a deterministic value (i.e. a boolean field that is always `false`) or
3. My field is very hard to compute (i.e uses refinements).

Specifying an override skips the field generation entirely.

Closes #2