### PR TITLE
feat: Deterministic pseudorandom values

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eslint": "^7.23.0",
     "eslint-config-dipasqualew": "^1.1.1",
     "jest": "^26.6.3",
+    "superjson": "^1.7.3",
     "ts-jest": "^26.5.4",
     "typescript": "^4.2.3"
   },

--- a/src/literal.ts
+++ b/src/literal.ts
@@ -1,12 +1,15 @@
 import type { ZodLiteral } from 'zod';
 
+import type { MockOptions } from './types';
+
 /**
  * Generates valid literal mock
  * from the given ZodLiteral definition
  *
  * @param field
+ * @param _options
  */
-export const mockValid = <T>(field: ZodLiteral<T>) => {
+export const mockValid = <T>(field: ZodLiteral<T>, _options: MockOptions<T>) => {
   return {
     DEFAULT: field._def.value,
   };
@@ -17,8 +20,9 @@ export const mockValid = <T>(field: ZodLiteral<T>) => {
  * from the given ZodLiteral definition
  *
  * @param field
+ * @param _options
  */
-export const mockInvalid = <T>(field: ZodLiteral<T>) => {
+export const mockInvalid = <T>(field: ZodLiteral<T>, _options: MockOptions<T>) => {
   return {
     // This will catch all values
     // and transform it to something else

--- a/src/primitives/any.ts
+++ b/src/primitives/any.ts
@@ -1,12 +1,15 @@
 import type { ZodAny, ZodUnknown } from 'zod';
 
+import type { MockOptions } from '../types';
+
 /**
  * Generates valid any/unknown mocks
  * from the given ZodAny/ZodUnknown definition
  *
  * @param _field
+ * @param _options
  */
-export const mockValid = (_field: ZodAny | ZodUnknown) => {
+export const mockValid = (_field: ZodAny | ZodUnknown, _options: MockOptions<unknown>) => {
   return {
     DEFAULT: 1,
   };
@@ -17,8 +20,9 @@ export const mockValid = (_field: ZodAny | ZodUnknown) => {
  * from the given ZodAny/ZodUnknown definition
  *
  * @param _field
+ * @param _options
  */
-export const mockInvalid = (_field: ZodAny | ZodUnknown) => {
+export const mockInvalid = (_field: ZodAny | ZodUnknown, _options: MockOptions<unknown>) => {
   // Any and Unknown are always valid
   return {};
 };

--- a/src/primitives/bigint.ts
+++ b/src/primitives/bigint.ts
@@ -1,5 +1,6 @@
 import type { ZodBigInt } from 'zod';
 
+import type { MockOptions } from '../types';
 import { MAX_INTEGER, MIN_INTEGER, getRandomNumber } from '../utils';
 
 /**
@@ -7,13 +8,14 @@ import { MAX_INTEGER, MIN_INTEGER, getRandomNumber } from '../utils';
  * from the given ZodBigInt definition
  *
  * @param _field
+ * @param options
  */
-export const mockValid = (_field: ZodBigInt) => {
+export const mockValid = (_field: ZodBigInt, options: MockOptions<BigInt>) => {
   const min = MIN_INTEGER;
   const max = MAX_INTEGER;
 
   const numbers = {
-    DEFAULT: BigInt(getRandomNumber(min, max, true)),
+    DEFAULT: BigInt(getRandomNumber(min, max, true, options.rng)),
     MIN: BigInt(min),
     MAX: BigInt(max),
   };
@@ -26,14 +28,15 @@ export const mockValid = (_field: ZodBigInt) => {
  * from the given ZodBigInt definition
  *
  * @param _field
+ * @param options
  */
-export const mockInvalid = (_field: ZodBigInt) => {
+export const mockInvalid = (_field: ZodBigInt, options: MockOptions<BigInt>) => {
   const min = MIN_INTEGER;
   const max = MAX_INTEGER;
 
   return {
     DEFAULT: 'not-a-number',
-    NUMBER: getRandomNumber(min, max, true),
-    FLOAT: getRandomNumber(min, max, true) + 0.1,
+    NUMBER: getRandomNumber(min, max, true, options.rng),
+    FLOAT: getRandomNumber(min, max, true, options.rng) + 0.1,
   };
 };

--- a/src/primitives/boolean.ts
+++ b/src/primitives/boolean.ts
@@ -1,12 +1,15 @@
 import type { ZodBoolean } from 'zod';
 
+import type { MockOptions } from '../types';
+
 /**
  * Generates valid boolean mocks
  * from the given ZodBoolean definition
  *
  * @param _field
+ * @param _options
  */
-export const mockValid = (_field: ZodBoolean) => {
+export const mockValid = (_field: ZodBoolean, _options: MockOptions<boolean>) => {
   const booleans = {
     DEFAULT: true,
     TRUE: true,
@@ -21,8 +24,9 @@ export const mockValid = (_field: ZodBoolean) => {
  * from the given ZodBoolean definition
  *
  * @param _field
+ * @param _options
  */
-export const mockInvalid = (_field: ZodBoolean) => {
+export const mockInvalid = (_field: ZodBoolean, _options: MockOptions<boolean>) => {
   const booleans = {
     DEFAULT: NaN,
   };

--- a/src/primitives/date.ts
+++ b/src/primitives/date.ts
@@ -1,14 +1,18 @@
 import type { ZodDate } from 'zod';
 
+import type { MockOptions } from '../types';
+import { getRandomDate } from '../utils';
+
 /**
  * Generates valid boolean mocks
  * from the given ZodDate definition
  *
  * @param _field
+ * @param options
  */
-export const mockValid = (_field: ZodDate) => {
+export const mockValid = (_field: ZodDate, options: MockOptions<Date>) => {
   const booleans = {
-    DEFAULT: new Date(),
+    DEFAULT: getRandomDate('week', options.rng),
   };
 
   return booleans;
@@ -19,8 +23,9 @@ export const mockValid = (_field: ZodDate) => {
  * from the given ZodDate definition
  *
  * @param _field
+ * @param _options
  */
-export const mockInvalid = (_field: ZodDate) => {
+export const mockInvalid = (_field: ZodDate, _options: MockOptions<Date>) => {
   const booleans = {
     DEFAULT: 'not-a-date',
     INVALID_DATE: new Date('not-a-date'),

--- a/src/primitives/null.ts
+++ b/src/primitives/null.ts
@@ -1,12 +1,15 @@
 import type { ZodNull } from 'zod';
 
+import type { MockOptions } from '../types';
+
 /**
  * Generates valid null mocks
  * from the given ZodNull definition
  *
  * @param _field
+ * @param _options
  */
-export const mockValid = (_field: ZodNull) => {
+export const mockValid = (_field: ZodNull, _options: MockOptions<null>) => {
   return {
     DEFAULT: null,
   };
@@ -17,8 +20,9 @@ export const mockValid = (_field: ZodNull) => {
  * from the given ZodNull definition
  *
  * @param _field
+ * @param _options
  */
-export const mockInvalid = (_field: ZodNull) => {
+export const mockInvalid = (_field: ZodNull, _options: MockOptions<null>) => {
   return {
     DEFAULT: 'DEFAULT',
     STRING: 'STRING',

--- a/src/primitives/number.ts
+++ b/src/primitives/number.ts
@@ -1,5 +1,6 @@
 import type { ZodNumber } from 'zod';
 
+import type { MockOptions } from '../types';
 import { MAX_INTEGER, MIN_INTEGER, getRandomNumber } from '../utils';
 
 /**
@@ -7,14 +8,15 @@ import { MAX_INTEGER, MIN_INTEGER, getRandomNumber } from '../utils';
  * from the given ZodNumber definition
  *
  * @param field
+ * @param options
  */
-export const mockValid = (field: ZodNumber) => {
+export const mockValid = (field: ZodNumber, options: MockOptions<number>) => {
   const min = field._def.minimum?.value || MIN_INTEGER;
   const max = field._def.maximum?.value || MAX_INTEGER;
   const integer = Boolean(field._def.isInteger);
 
   const numbers = {
-    DEFAULT: getRandomNumber(min, max, integer),
+    DEFAULT: getRandomNumber(min, max, integer, options.rng),
     MIN: min,
     MAX: max,
   };
@@ -27,8 +29,9 @@ export const mockValid = (field: ZodNumber) => {
  * from the given ZodNumber definition
  *
  * @param field
+ * @param options
  */
-export const mockInvalid = (field: ZodNumber) => {
+export const mockInvalid = (field: ZodNumber, options: MockOptions<number>) => {
   const integer = Boolean(field._def.isInteger);
 
   const strings: [string, string | number][] = [
@@ -36,17 +39,17 @@ export const mockInvalid = (field: ZodNumber) => {
   ];
 
   if (field._def.minimum) {
-    const underMin = getRandomNumber(MIN_INTEGER, field._def.minimum.value - 1);
+    const underMin = getRandomNumber(MIN_INTEGER, field._def.minimum.value - 1, false, options.rng);
     strings.push(['MIN', underMin]);
   }
 
   if (field._def.maximum) {
-    const overMax = getRandomNumber(field._def.maximum.value + 1, MAX_INTEGER);
+    const overMax = getRandomNumber(field._def.maximum.value + 1, MAX_INTEGER, false, options.rng);
     strings.push(['MAX', overMax]);
   }
 
   if (integer) {
-    const float = getRandomNumber(field._def.minimum?.value || 0, field._def.maximum?.value || 20, true) + 0.1;
+    const float = getRandomNumber(field._def.minimum?.value || 0, field._def.maximum?.value || 20, true, options.rng) + 0.1;
     strings.push(['FLOAT', float]);
   }
 

--- a/src/primitives/undefined.ts
+++ b/src/primitives/undefined.ts
@@ -1,12 +1,14 @@
 import type { ZodUndefined, ZodVoid } from 'zod';
 
+import { MockOptions } from '../types';
 /**
  * Generates valid undefined mocks
  * from the given ZodUndefined | ZodVoid definition
  *
  * @param _field
+ * @param _options
  */
-export const mockValid = (_field: ZodUndefined | ZodVoid) => {
+export const mockValid = (_field: ZodUndefined | ZodVoid, _options: MockOptions<undefined>) => {
   return {
     DEFAULT: undefined,
     UNDEFINED: undefined,
@@ -20,8 +22,9 @@ export const mockValid = (_field: ZodUndefined | ZodVoid) => {
  * from the given ZodUndefined | ZodVoid definition
  *
  * @param _field
+ * @param _options
  */
-export const mockInvalid = (_field: ZodUndefined | ZodVoid) => {
+export const mockInvalid = (_field: ZodUndefined | ZodVoid, _options: MockOptions<undefined>) => {
   return {
     DEFAULT: 'DEFAULT',
     STRING: 'STRING',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
+/**
+ * Represents a seed value
+ */
+export type Seed = number | boolean | null;
+
+export type RNG = () => number;
 
 /**
  * Recursively applies Partial
@@ -30,7 +36,9 @@ export type PartialKeys<T> = {
  * that can be passed to a mock function
  */
 export interface MockOptions<T> {
-  override?: DeepPartial<T> | (() => DeepPartial<T>)
+  override?: DeepPartial<T> | (() => DeepPartial<T>);
+  seed?: Seed;
+  rng?: RNG;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,7 @@
+import { v4 as uuidv4, v5 as uuidv5 } from 'uuid';
+
+import type { RNG, Seed } from './types';
+
 /**
  * Latin alphabet
  */
@@ -5,15 +9,82 @@ export const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz012
 
 export const MIN_INTEGER = Math.round(Number.MIN_SAFE_INTEGER / 3);
 export const MAX_INTEGER = Math.round(Number.MAX_SAFE_INTEGER / 3);
+export const UUID_NAMESPACE = 'ffe92c7d-e22c-4935-a798-671a4b3742e4';
+
+
+/**
+ * Casts a string to a number.
+ * The number is not unique per string,
+ * so this function should not be used where unique
+ * values are expected.
+ *
+ * @param str
+ */
+export const arbitraryStringToNumber = (str: string) => {
+  return str.split('').reduce((acc, current) => acc + current.charCodeAt(0), 0);
+};
+
+/**
+ * Casts an object to a number.
+ * The number is not unique per object,
+ * so this function should not be used where unique
+ * values are expected.
+ *
+ * @param obj
+ */
+export const arbitraryObjectToNumber = (obj: unknown) => {
+  return arbitraryStringToNumber(JSON.stringify(obj));
+};
+
+/**
+ * Creates a fairly simple RNG
+ * from the given seed.
+ * See: https://stackoverflow.com/a/47593316
+ *
+ * @param seed
+ */
+export const mulberry32 = (seed: number) => {
+  let hoisted = seed;
+  /* eslint-disable no-bitwise */
+  return () => {
+    hoisted += 0x6D2B79F5;
+    let t = hoisted;
+
+    t = Math.imul(t ^ t >>> 15, t | 1);
+    t ^= t + Math.imul(t ^ t >>> 7, t | 61);
+    return ((t ^ t >>> 14) >>> 0) / 4294967296;
+  };
+};
+
+/**
+ * Returns a random number generator
+ * given a seed:
+ *
+ * - If seed is `true` or a number
+ *   it returns the associated mulberry32 (bool is casted)
+ *
+ * - If seed is `null` it returns Math.random
+ *
+ * @param seed
+ */
+export const getRng = (seed: Seed): RNG => {
+  if (seed === null) {
+    return Math.random;
+  }
+
+  return mulberry32(Number(seed));
+};
+
 
 /**
  * Returns a random element
  * from the given array
  *
  * @param origin
+ * @param rng
  */
-export const getRandomElement = <T>(origin: T[]): T => {
-  const index = Math.floor(Math.random() * origin.length);
+export const getRandomElement = <T>(origin: T[], rng: RNG = Math.random): T => {
+  const index = Math.floor(rng() * origin.length);
   const item = origin[index];
 
   return item;
@@ -26,12 +97,13 @@ export const getRandomElement = <T>(origin: T[]): T => {
  * @param min
  * @param max
  * @param integer Whether the number should be an integer
+ * @param rng
  */
-export const getRandomNumber = (min: number, max: number, integer = false): number => {
+export const getRandomNumber = (min: number, max: number, integer = false, rng: RNG = Math.random): number => {
   const safeMin = Math.max(min, MIN_INTEGER);
   const safeMax = Math.min(max, MAX_INTEGER);
 
-  const num = (Math.random() * (safeMax - safeMin)) + safeMin;
+  const num = (rng() * (safeMax - safeMin)) + safeMin;
 
   if (integer) {
     return Math.floor(num);
@@ -47,9 +119,10 @@ export const getRandomNumber = (min: number, max: number, integer = false): numb
  *
  * @param length
  * @param alphabet
+ * @param rng
  */
-export const getString = (length: number, alphabet = ALPHABET): string => {
-  const elements = Array.from({ length }).map(() => getRandomElement(alphabet));
+export const getString = (length: number, alphabet = ALPHABET, rng: RNG = Math.random): string => {
+  const elements = Array.from({ length }).map(() => getRandomElement(alphabet, rng));
 
   return elements.join('');
 };
@@ -61,11 +134,12 @@ export const getString = (length: number, alphabet = ALPHABET): string => {
  * @param minLength
  * @param maxLength
  * @param alphabet
+ * @param rng
  */
-export const getRandomString = (minLength: number, maxLength: number, alphabet = ALPHABET): string => {
-  const length = getRandomNumber(minLength, maxLength, true);
+export const getRandomString = (minLength: number, maxLength: number, alphabet = ALPHABET, rng: RNG = Math.random): string => {
+  const length = getRandomNumber(minLength, maxLength, true, rng);
 
-  return getString(length, alphabet);
+  return getString(length, alphabet, rng);
 };
 
 /**
@@ -75,12 +149,13 @@ export const getRandomString = (minLength: number, maxLength: number, alphabet =
  * @param minLength
  * @param maxLength
  * @param domain
+ * @param rng
  */
-export const getRandomEmail = (minLength: number, maxLength: number, domain = 'example.com') => {
+export const getRandomEmail = (minLength: number, maxLength: number, domain = 'example.com', rng: RNG = Math.random) => {
   const normalisedMinlength = Math.max(1, minLength - domain.length - 1); // remove @ and domain length
   const normalisedMaxLength = Math.max(1, maxLength - domain.length - 1); // remove @ and domain length
 
-  const user = getRandomString(normalisedMinlength, normalisedMaxLength);
+  const user = getRandomString(normalisedMinlength, normalisedMaxLength, ALPHABET, rng);
 
   return `${user}@${domain}`;
 };
@@ -92,12 +167,61 @@ export const getRandomEmail = (minLength: number, maxLength: number, domain = 'e
  * @param minLength
  * @param maxLength
  * @param domain
+ * @param rng
  */
-export const getRandomUrl = (minLength: number, maxLength: number, domain = 'example.com') => {
+export const getRandomUrl = (minLength: number, maxLength: number, domain = 'example.com', rng: RNG = Math.random) => {
   const normalisedMinlength = Math.max(1, minLength - domain.length - 9); // remove https://, domain length and initial slash
   const normalisedMaxLength = Math.max(1, maxLength - domain.length - 9); // remove https://, domain length and initial slash
 
-  const path = getRandomString(normalisedMinlength, normalisedMaxLength);
+  const path = getRandomString(normalisedMinlength, normalisedMaxLength, ALPHABET, rng);
 
   return `https://${domain}/${path}`;
+};
+
+export type DateVariance = 'hour' | 'day' | 'week';
+
+/**
+ * Generates a random Date with the given
+ * constraints
+ *
+ * @param variance Maximum variance from the base (Defaults to a 24h)
+ * @param rng
+ */
+export const getRandomDate = (variance: DateVariance, rng: RNG = Math.random) => {
+  const varianceValue = {
+    hour: 3600,
+    day: 86400000,
+    week: 604800000,
+  }[variance];
+
+  const multiplier = (rng() - 0.5) * 2; // get a number between -1 and 1
+
+  let start = Date.now();
+
+  if (rng !== Math.random) {
+    // If we have a seed, scrap Date.now and be deterministic
+    // Sun Mar 28 2021 12:38:18 GMT+0100 (British Summer Time)
+    start = 1616931407502;
+  }
+  const unix = start + (varianceValue * multiplier);
+
+  return new Date(unix);
+};
+
+/**
+ * Returns a UUID
+ *
+ * If seed is defined, it uses UUID v5
+ * for deterministic UUIDs
+ *
+ * @param rng
+ */
+export const getUUID = (rng: RNG = Math.random) => {
+  if (rng === Math.random) {
+    return uuidv4();
+  }
+
+  const name = String(rng());
+
+  return uuidv5(name, UUID_NAMESPACE);
 };

--- a/tests/__snapshots__/utils.spec.ts.snap
+++ b/tests/__snapshots__/utils.spec.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`utils getUUID with a seed returns a sequence of deterministic UUIDs 1`] = `
+Array [
+  "c994787c-3b4c-5e2f-81de-33ab9b048e46",
+  "2bd4f558-ee91-5183-bcf8-c5663aa32b54",
+  "9d6fc420-dfc7-5aeb-838c-4b94e6d797f2",
+]
+`;

--- a/tests/mixins.ts
+++ b/tests/mixins.ts
@@ -1,3 +1,4 @@
+import superjson from 'superjson';
 import * as zod from 'zod';
 
 import { mock } from '../src/fields';
@@ -94,6 +95,34 @@ export const overrideTest = <T extends zod.ZodAny>(instances: [string, T][], ove
               expect(value).toEqual(override);
             });
           });
+        });
+      });
+    });
+  });
+};
+
+/**
+ * Tests overrides
+ *
+ * @param instances
+ */
+export const seedTest = <T extends zod.ZodAny>(instances: [string, T][]) => {
+  instances.forEach(([description, field]) => {
+    describe(description, () => {
+      describe('generates deterministic values', () => {
+        const batch1 = mock(field, { seed: 99 });
+        const batch2 = mock(field, { seed: 99 });
+
+        it('the valid mocks', () => {
+          // needs to be serialized because of jest same ref problems
+          // needs superjson because of bigint
+          expect(superjson.stringify(batch1.valid)).toEqual(superjson.stringify(batch2.valid));
+        });
+
+        it('the invalid mocks', () => {
+          // needs to be serialized because of jest same ref problems
+          // needs superjson because of bigint
+          expect(superjson.stringify(batch1.invalid)).toEqual(superjson.stringify(batch2.invalid));
         });
       });
     });

--- a/tests/objects.spec.ts
+++ b/tests/objects.spec.ts
@@ -41,7 +41,7 @@ describe('object', () => {
     };
 
     describe('overrides the key', () => {
-      const { valid } = mock(complexField, { override });
+      const { valid } = mock(complexField, { override, seed: 1 });
 
       Object.entries(valid).forEach(([key, value]) => {
         it(`Overrides ${key} root.nested.max`, () => {

--- a/tests/primitives/any.spec.ts
+++ b/tests/primitives/any.spec.ts
@@ -1,9 +1,10 @@
 import { DeepPartial } from '../../src/types';
 import { anyFields } from '../fields';
-import { overrideTest, validationTests } from '../mixins';
+import { overrideTest, seedTest, validationTests } from '../mixins';
 
 describe('any', () => {
   validationTests(anyFields);
   overrideTest(anyFields, 'Dante Alighieri' as DeepPartial<unknown>);
   overrideTest(anyFields, 1265 as DeepPartial<unknown>);
+  seedTest(anyFields);
 });

--- a/tests/primitives/bigint.spec.ts
+++ b/tests/primitives/bigint.spec.ts
@@ -1,8 +1,9 @@
 import { bigintFields } from '../fields';
-import { overrideTest, validationTests } from '../mixins';
+import { overrideTest, seedTest, validationTests } from '../mixins';
 
 describe('bigint', () => {
   validationTests(bigintFields);
   overrideTest(bigintFields, BigInt(100));
   overrideTest(bigintFields, BigInt(-100));
+  seedTest(bigintFields);
 });

--- a/tests/primitives/boolean.spec.ts
+++ b/tests/primitives/boolean.spec.ts
@@ -1,8 +1,9 @@
 import { booleanFields } from '../fields';
-import { overrideTest, validationTests } from '../mixins';
+import { overrideTest, seedTest, validationTests } from '../mixins';
 
 describe('boolean', () => {
   validationTests(booleanFields);
   overrideTest(booleanFields, true);
   overrideTest(booleanFields, false);
+  seedTest(booleanFields);
 });

--- a/tests/primitives/date.spec.ts
+++ b/tests/primitives/date.spec.ts
@@ -1,7 +1,8 @@
 import { dateFields } from '../fields';
-import { overrideTest, validationTests } from '../mixins';
+import { overrideTest, seedTest, validationTests } from '../mixins';
 
 describe('date', () => {
   validationTests(dateFields);
   overrideTest(dateFields, new Date('1265-05-01'));
+  seedTest(dateFields);
 });

--- a/tests/primitives/null.spec.ts
+++ b/tests/primitives/null.spec.ts
@@ -1,7 +1,8 @@
 import { nullFields } from '../fields';
-import { overrideTest, validationTests } from '../mixins';
+import { overrideTest, seedTest, validationTests } from '../mixins';
 
 describe('null', () => {
   validationTests(nullFields);
   overrideTest(nullFields, null);
+  seedTest(nullFields);
 });

--- a/tests/primitives/number.spec.ts
+++ b/tests/primitives/number.spec.ts
@@ -1,5 +1,5 @@
 import { numberFields } from '../fields';
-import { overrideTest, validationTests } from '../mixins';
+import { overrideTest, seedTest, validationTests } from '../mixins';
 
 describe('number', () => {
   validationTests(numberFields);
@@ -9,4 +9,5 @@ describe('number', () => {
   overrideTest(numberFields, Math.PI);
   overrideTest(numberFields, Infinity);
   overrideTest(numberFields, -Infinity);
+  seedTest(numberFields);
 });

--- a/tests/primitives/string.spec.ts
+++ b/tests/primitives/string.spec.ts
@@ -1,8 +1,9 @@
 import { stringFields } from '../fields';
-import { overrideTest, validationTests } from '../mixins';
+import { overrideTest, seedTest, validationTests } from '../mixins';
 
 describe('string', () => {
   validationTests(stringFields);
   overrideTest(stringFields, 'my-string');
   overrideTest(stringFields, '');
+  seedTest(stringFields);
 });

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -1,0 +1,70 @@
+import { getUUID, mulberry32 } from '../src/utils';
+
+describe('utils', () => {
+  describe('mulberry32', () => {
+    it('returns random numbers', () => {
+      const rng = mulberry32(1);
+      const length = 10000;
+      const arr = Array.from({ length }).map(() => rng());
+      const set = new Set(arr);
+      expect(set.size).toEqual(length);
+    });
+
+    it('instances from the same seed return the same sequence', () => {
+      const rng1 = mulberry32(1);
+      const rng2 = mulberry32(1);
+
+      const length = 500;
+
+      const set = new Set();
+
+      for (let i = 0; i < length; i += 1) {
+        set.add(rng1());
+        set.add(rng2());
+
+        expect(set.size).toEqual(i + 1);
+      }
+    });
+
+    it('instances from different seeds return the different sequences', () => {
+      const rng1 = mulberry32(1);
+      const rng2 = mulberry32(2);
+
+      const length = 500;
+
+      const set = new Set();
+
+      for (let i = 0; i < length; i += 1) {
+        set.add(rng1());
+        set.add(rng2());
+
+        expect(set.size).toEqual((i + 1) * 2);
+      }
+    });
+  });
+
+  describe('getUUID', () => {
+    describe('without a seed', () => {
+      it('returns a random UUID', () => {
+        const length = 500;
+        const arr = Array.from({ length }).map(() => getUUID());
+        const set = new Set(arr);
+
+        expect(set.size).toEqual(length);
+      });
+    });
+
+    describe('with a seed', () => {
+      it('returns a sequence of deterministic UUIDs', () => {
+        const rng = mulberry32(1);
+        const uuids = [
+          getUUID(rng),
+          getUUID(rng),
+          getUUID(rng),
+        ];
+
+        expect(uuids).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4161,6 +4161,13 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+superjson@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/superjson/-/superjson-1.7.3.tgz#2544f7fab70f4251b02bb646c5c519b7131e9db9"
+  integrity sha512-9BmEeJubbs9dUxWxn1I7+VLgdFv895q7BlCGh948IdD/5/RpDjQ6M0tNJJn88Sp/wswJGGuMrG5ii+ZQhoKzwQ==
+  dependencies:
+    debug "^4.3.1"
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"


### PR DESCRIPTION
As a library user, I'd like to be able to specify a seed, or let `zod-mocking` to use a seed, so that I can produce consistent mock values.

In other words:

1. `mock(myField, { seed: 1 }) === mock(myField, { seed: 1 });`
2. `mock(myField, { seed: 1 }) !== mock(myField, { seed: 2 });`
3. `mock(myField, { seed: true }) === mock(myField, { seed: 1 })`;
4. `mock(myField) !== mock(myField, { seed: 1 })`;
5. `mock(myField) !== mock(myField)`;

Closes #3