### PR TITLE
feat: Support transforms

### DIFF
--- a/tests/primitives/__snapshots__/string.spec.ts.snap
+++ b/tests/primitives/__snapshots__/string.spec.ts.snap
@@ -397,3 +397,15 @@ exports[`string an email field without min nor max invalidates Invalidates DEFAU
   }
 ]"
 `;
+
+exports[`string effects Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"string\\",
+    \\"received\\": \\"null\\",
+    \\"path\\": [],
+    \\"message\\": \\"Expected string, received null\\"
+  }
+]"
+`;

--- a/tests/primitives/string.spec.ts
+++ b/tests/primitives/string.spec.ts
@@ -1,9 +1,30 @@
+import * as zod from 'zod';
+
+import { mock } from '../../src/fields';
 import { stringFields } from '../fields';
-import { overrideTest, seedTest, validationTests } from '../mixins';
+import {
+  invalidateGroup, overrideTest, seedTest, validationTests,
+} from '../mixins';
 
 describe('string', () => {
   validationTests(stringFields);
   overrideTest(stringFields, 'my-string');
   overrideTest(stringFields, '');
   seedTest(stringFields);
+
+  describe('effects', () => {
+    const effect = zod.string().transform((value) => `${value} by Dante Alighieri`).transform((value) => value.toUpperCase());
+    const { valid, invalid } = mock(effect);
+
+    // They are still invalid
+    invalidateGroup(effect, invalid);
+
+    describe('casts the valid values', () => {
+      Object.entries(valid).forEach(([key, value]) => {
+        it(key, () => {
+          expect(value.endsWith(' BY DANTE ALIGHIERI')).toEqual(true);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Zod fields can specify transforms functions that are used to cast or transform the validated value.

Mock generators should perform he same transformations.

Closes #5