### PR TITLE
fix: Support number's positive, negative, nonpositive, nonnegative

### DIFF
--- a/src/primitives/number.ts
+++ b/src/primitives/number.ts
@@ -11,8 +11,17 @@ import { MAX_INTEGER, MIN_INTEGER, getRandomNumber } from '../utils';
  * @param options
  */
 export const mockValid = (field: ZodNumber, options: MockOptions<number>) => {
-  const min = field._def.minimum?.value || MIN_INTEGER;
-  const max = field._def.maximum?.value || MAX_INTEGER;
+  let min = field._def.minimum?.value ?? MIN_INTEGER;
+  let max = field._def.maximum?.value ?? MAX_INTEGER;
+
+  if (!field._def.minimum?.inclusive) {
+    min += 1;
+  }
+
+  if (!field._def.maximum?.inclusive) {
+    max -= 1;
+  }
+
   const integer = Boolean(field._def.isInteger);
 
   const numbers = {

--- a/tests/__snapshots__/array.spec.ts.snap
+++ b/tests/__snapshots__/array.spec.ts.snap
@@ -483,6 +483,78 @@ exports[`array an array from a field without min or max invalidates Invalidates 
 ]"
 `;
 
+exports[`array an array from a negative field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      0
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"too_big\\",
+    \\"maximum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": false,
+    \\"message\\": \\"Value should be less than 0\\",
+    \\"path\\": [
+      1
+    ]
+  }
+]"
+`;
+
+exports[`array an array from a nonnegative field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      0
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"too_small\\",
+    \\"minimum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": true,
+    \\"message\\": \\"Value should be greater than or equal to 0\\",
+    \\"path\\": [
+      1
+    ]
+  }
+]"
+`;
+
+exports[`array an array from a nonpositive field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      0
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"too_big\\",
+    \\"maximum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": true,
+    \\"message\\": \\"Value should be less than or equal to 0\\",
+    \\"path\\": [
+      1
+    ]
+  }
+]"
+`;
+
 exports[`array an array from a null field invalidates Invalidates DEFAULT 1`] = `
 "[
   {
@@ -525,6 +597,30 @@ exports[`array an array from a number literal invalidates Invalidates DEFAULT 1`
       0
     ],
     \\"message\\": \\"Expected 1265, received false\\"
+  }
+]"
+`;
+
+exports[`array an array from a positive field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      0
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"too_small\\",
+    \\"minimum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": false,
+    \\"message\\": \\"Value should be greater than 0\\",
+    \\"path\\": [
+      1
+    ]
   }
 ]"
 `;
@@ -1441,6 +1537,114 @@ exports[`array an array from an object from a field without min or max invalidat
 ]"
 `;
 
+exports[`array an array from an object from a negative field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      0,
+      \\"number\\"
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      1,
+      \\"number\\"
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"too_big\\",
+    \\"maximum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": false,
+    \\"message\\": \\"Value should be less than 0\\",
+    \\"path\\": [
+      2,
+      \\"number\\"
+    ]
+  }
+]"
+`;
+
+exports[`array an array from an object from a nonnegative field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      0,
+      \\"number\\"
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      1,
+      \\"number\\"
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"too_small\\",
+    \\"minimum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": true,
+    \\"message\\": \\"Value should be greater than or equal to 0\\",
+    \\"path\\": [
+      2,
+      \\"number\\"
+    ]
+  }
+]"
+`;
+
+exports[`array an array from an object from a nonpositive field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      0,
+      \\"number\\"
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      1,
+      \\"number\\"
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"too_big\\",
+    \\"maximum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": true,
+    \\"message\\": \\"Value should be less than or equal to 0\\",
+    \\"path\\": [
+      2,
+      \\"number\\"
+    ]
+  }
+]"
+`;
+
 exports[`array an array from an object from a null field invalidates Invalidates DEFAULT 1`] = `
 "[
   {
@@ -1507,6 +1711,42 @@ exports[`array an array from an object from a number literal invalidates Invalid
       \\"string\\"
     ],
     \\"message\\": \\"Expected 1265, received false\\"
+  }
+]"
+`;
+
+exports[`array an array from an object from a positive field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      0,
+      \\"number\\"
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      1,
+      \\"number\\"
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"too_small\\",
+    \\"minimum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": false,
+    \\"message\\": \\"Value should be greater than 0\\",
+    \\"path\\": [
+      2,
+      \\"number\\"
+    ]
   }
 ]"
 `;

--- a/tests/__snapshots__/objects.spec.ts.snap
+++ b/tests/__snapshots__/objects.spec.ts.snap
@@ -1125,6 +1125,135 @@ exports[`object an object from a field without min or max invalidates Invalidate
 ]"
 `;
 
+exports[`object an object from a negative field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      \\"number\\"
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  }
+]"
+`;
+
+exports[`object an object from a negative field invalidates Invalidates number__DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      \\"number\\"
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  }
+]"
+`;
+
+exports[`object an object from a negative field invalidates Invalidates number__MAX 1`] = `
+"[
+  {
+    \\"code\\": \\"too_big\\",
+    \\"maximum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": false,
+    \\"message\\": \\"Value should be less than 0\\",
+    \\"path\\": [
+      \\"number\\"
+    ]
+  }
+]"
+`;
+
+exports[`object an object from a nonnegative field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      \\"number\\"
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  }
+]"
+`;
+
+exports[`object an object from a nonnegative field invalidates Invalidates number__DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      \\"number\\"
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  }
+]"
+`;
+
+exports[`object an object from a nonnegative field invalidates Invalidates number__MIN 1`] = `
+"[
+  {
+    \\"code\\": \\"too_small\\",
+    \\"minimum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": true,
+    \\"message\\": \\"Value should be greater than or equal to 0\\",
+    \\"path\\": [
+      \\"number\\"
+    ]
+  }
+]"
+`;
+
+exports[`object an object from a nonpositive field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      \\"number\\"
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  }
+]"
+`;
+
+exports[`object an object from a nonpositive field invalidates Invalidates number__DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      \\"number\\"
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  }
+]"
+`;
+
+exports[`object an object from a nonpositive field invalidates Invalidates number__MAX 1`] = `
+"[
+  {
+    \\"code\\": \\"too_big\\",
+    \\"maximum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": true,
+    \\"message\\": \\"Value should be less than or equal to 0\\",
+    \\"path\\": [
+      \\"number\\"
+    ]
+  }
+]"
+`;
+
 exports[`object an object from a null field invalidates Invalidates DEFAULT 1`] = `
 "[
   {
@@ -1205,6 +1334,49 @@ exports[`object an object from a number literal invalidates Invalidates string__
       \\"string\\"
     ],
     \\"message\\": \\"Expected 1265, received false\\"
+  }
+]"
+`;
+
+exports[`object an object from a positive field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      \\"number\\"
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  }
+]"
+`;
+
+exports[`object an object from a positive field invalidates Invalidates number__DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      \\"number\\"
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  }
+]"
+`;
+
+exports[`object an object from a positive field invalidates Invalidates number__MIN 1`] = `
+"[
+  {
+    \\"code\\": \\"too_small\\",
+    \\"minimum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": false,
+    \\"message\\": \\"Value should be greater than 0\\",
+    \\"path\\": [
+      \\"number\\"
+    ]
   }
 ]"
 `;
@@ -2343,6 +2515,162 @@ exports[`object an object from an array from a field without min or max invalida
 ]"
 `;
 
+exports[`object an object from an array from a negative field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      \\"string\\",
+      0
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"too_big\\",
+    \\"maximum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": false,
+    \\"message\\": \\"Value should be less than 0\\",
+    \\"path\\": [
+      \\"string\\",
+      1
+    ]
+  }
+]"
+`;
+
+exports[`object an object from an array from a negative field invalidates Invalidates string__DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      \\"string\\",
+      0
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"too_big\\",
+    \\"maximum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": false,
+    \\"message\\": \\"Value should be less than 0\\",
+    \\"path\\": [
+      \\"string\\",
+      1
+    ]
+  }
+]"
+`;
+
+exports[`object an object from an array from a nonnegative field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      \\"string\\",
+      0
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"too_small\\",
+    \\"minimum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": true,
+    \\"message\\": \\"Value should be greater than or equal to 0\\",
+    \\"path\\": [
+      \\"string\\",
+      1
+    ]
+  }
+]"
+`;
+
+exports[`object an object from an array from a nonnegative field invalidates Invalidates string__DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      \\"string\\",
+      0
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"too_small\\",
+    \\"minimum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": true,
+    \\"message\\": \\"Value should be greater than or equal to 0\\",
+    \\"path\\": [
+      \\"string\\",
+      1
+    ]
+  }
+]"
+`;
+
+exports[`object an object from an array from a nonpositive field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      \\"string\\",
+      0
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"too_big\\",
+    \\"maximum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": true,
+    \\"message\\": \\"Value should be less than or equal to 0\\",
+    \\"path\\": [
+      \\"string\\",
+      1
+    ]
+  }
+]"
+`;
+
+exports[`object an object from an array from a nonpositive field invalidates Invalidates string__DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      \\"string\\",
+      0
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"too_big\\",
+    \\"maximum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": true,
+    \\"message\\": \\"Value should be less than or equal to 0\\",
+    \\"path\\": [
+      \\"string\\",
+      1
+    ]
+  }
+]"
+`;
+
 exports[`object an object from an array from a null field invalidates Invalidates DEFAULT 1`] = `
 "[
   {
@@ -2439,6 +2767,58 @@ exports[`object an object from an array from a number literal invalidates Invali
       0
     ],
     \\"message\\": \\"Expected 1265, received false\\"
+  }
+]"
+`;
+
+exports[`object an object from an array from a positive field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      \\"string\\",
+      0
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"too_small\\",
+    \\"minimum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": false,
+    \\"message\\": \\"Value should be greater than 0\\",
+    \\"path\\": [
+      \\"string\\",
+      1
+    ]
+  }
+]"
+`;
+
+exports[`object an object from an array from a positive field invalidates Invalidates string__DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [
+      \\"string\\",
+      0
+    ],
+    \\"message\\": \\"Expected number, received string\\"
+  },
+  {
+    \\"code\\": \\"too_small\\",
+    \\"minimum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": false,
+    \\"message\\": \\"Value should be greater than 0\\",
+    \\"path\\": [
+      \\"string\\",
+      1
+    ]
   }
 ]"
 `;

--- a/tests/fields.ts
+++ b/tests/fields.ts
@@ -39,6 +39,10 @@ export const numberFields: NumberTestCase[] = [
   ['a field with max', zod.number().max(10)],
   ['a field with min and max', zod.number().min(10).max(20)],
   ['a field with min === max', zod.number().min(10).max(10)],
+  ['a positive field', zod.number().positive()],
+  ['a negative field', zod.number().negative()],
+  ['a nonpositive field', zod.number().nonpositive()],
+  ['a nonnegative field', zod.number().nonnegative()],
   ['an integer field', zod.number().int()],
 ];
 

--- a/tests/primitives/__snapshots__/number.spec.ts.snap
+++ b/tests/primitives/__snapshots__/number.spec.ts.snap
@@ -138,6 +138,106 @@ exports[`number a field without min or max invalidates Invalidates DEFAULT 1`] =
 ]"
 `;
 
+exports[`number a negative field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [],
+    \\"message\\": \\"Expected number, received string\\"
+  }
+]"
+`;
+
+exports[`number a negative field invalidates Invalidates MAX 1`] = `
+"[
+  {
+    \\"code\\": \\"too_big\\",
+    \\"maximum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": false,
+    \\"message\\": \\"Value should be less than 0\\",
+    \\"path\\": []
+  }
+]"
+`;
+
+exports[`number a nonnegative field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [],
+    \\"message\\": \\"Expected number, received string\\"
+  }
+]"
+`;
+
+exports[`number a nonnegative field invalidates Invalidates MIN 1`] = `
+"[
+  {
+    \\"code\\": \\"too_small\\",
+    \\"minimum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": true,
+    \\"message\\": \\"Value should be greater than or equal to 0\\",
+    \\"path\\": []
+  }
+]"
+`;
+
+exports[`number a nonpositive field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [],
+    \\"message\\": \\"Expected number, received string\\"
+  }
+]"
+`;
+
+exports[`number a nonpositive field invalidates Invalidates MAX 1`] = `
+"[
+  {
+    \\"code\\": \\"too_big\\",
+    \\"maximum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": true,
+    \\"message\\": \\"Value should be less than or equal to 0\\",
+    \\"path\\": []
+  }
+]"
+`;
+
+exports[`number a positive field invalidates Invalidates DEFAULT 1`] = `
+"[
+  {
+    \\"code\\": \\"invalid_type\\",
+    \\"expected\\": \\"number\\",
+    \\"received\\": \\"string\\",
+    \\"path\\": [],
+    \\"message\\": \\"Expected number, received string\\"
+  }
+]"
+`;
+
+exports[`number a positive field invalidates Invalidates MIN 1`] = `
+"[
+  {
+    \\"code\\": \\"too_small\\",
+    \\"minimum\\": 0,
+    \\"type\\": \\"number\\",
+    \\"inclusive\\": false,
+    \\"message\\": \\"Value should be greater than 0\\",
+    \\"path\\": []
+  }
+]"
+`;
+
 exports[`number an integer field invalidates Invalidates DEFAULT 1`] = `
 "[
   {


### PR DESCRIPTION
At the moment the number mocker fails to take in account the number `0` for minimum and maximum and therefore casts them to `MIN_INTEGER` and `MAX_INTEGER`. The number `0` is used for the following modifiers:

- `number().positive()`
- `number().negative()`
- `number().nonpositive()`
- `number().nonnegative()`

Additionally, `number()._def.minimum.inclusive` and `number()._def.maximum.inclusive` should both be considered when generating the number.

Closes #9